### PR TITLE
Cache lm

### DIFF
--- a/R/basis_functions.R
+++ b/R/basis_functions.R
@@ -43,16 +43,16 @@ fourier_2d <- function(max_freqs, lattice_dim){
   l <- split(cbn, 1:nrow(cbn))[-1]
   l_sin_sin <- lapply(l, function(nm)
     return(
-      function(x, y, N, M) sin((x-1)*pi*nm[1,1]/N)*sin((y-1)*pi*nm[1,2]/M)))
+      function(x, y, N, M) sin(2*(x-1)*pi*nm[1,1]/N)*sin(2*(y-1)*pi*nm[1,2]/M)))
   l_cos_sin <- lapply(l, function(nm)
     return(
-      function(x, y, N, M) cos((x-1)*pi*nm[1,1]/N)*sin((y-1)*pi*nm[1,2]/M)))
+      function(x, y, N, M) cos(2*(x-1)*pi*nm[1,1]/N)*sin(2*(y-1)*pi*nm[1,2]/M)))
   l_sin_cos <- lapply(l, function(nm)
     return(
-      function(x, y, N, M) sin((x-1)*pi*nm[1,1]/N)*cos((y-1)*pi*nm[1,2]/M)))
+      function(x, y, N, M) sin(2*(x-1)*pi*nm[1,1]/N)*cos(2*(y-1)*pi*nm[1,2]/M)))
   l_cos_cos <- lapply(l, function(nm)
     return(
-      function(x, y, N, M) cos((x-1)*pi*nm[1,1]/N)*cos((y-1)*pi*nm[1,2]/M)))
+      function(x, y, N, M) cos(2*(x-1)*pi*nm[1,1]/N)*cos(2*(y-1)*pi*nm[1,2]/M)))
 
   return(c(l_sin_sin, l_cos_cos, l_cos_sin, l_sin_cos))
 }

--- a/R/fit_ghm.R
+++ b/R/fit_ghm.R
@@ -115,7 +115,7 @@ fit_ghm <- function(Y, mrfi, theta, fixed_fn = list(),
     ind_fit <- fit_ghm(e, mrfi, theta*0, fixed_fn, equal_vars,
                        init_mus = seq(min(e), max(e), length.out = C+1),
                        init_sigmas = rep(diff(range(e))/(2*C), C+1),
-                       maxiter, max_dist, icm_cycles, verbose = TRUE)
+                       maxiter, max_dist, icm_cycles, verbose = FALSE)
     mus_old <- ind_fit$par$mu
     sigmas_old <- ind_fit$par$sigma
   } else {


### PR DESCRIPTION
`fit_ghm()` now performs the matrix multiplications required to fit linear models. With this change, the matrix inversion (which only depends on the covariates matrix) can be done once and cached for posterior use, saving computational time when in each iteration of the EM algorithm.